### PR TITLE
make badge color modular

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,14 +43,42 @@
             data: field.key,
             title: field.title,
             visible: field.visible !== false,
-            render: (d, type, row) => {
-                if (field.format === 'currency') return `$${Number(d).toLocaleString()}`;
-                if (field.format === 'date') return new Date(d).toLocaleDateString();
-                if (field.key === 'status') {
-                    const cls = d === 'Active' ? 'bg-success' : 'bg-warning';
-                    return `<span class="badge ${cls}">${d}</span>`;
+            render: (data, type, row) => {
+                // If we're requesting the raw data for sorting/filtering, return it
+                if (type === 'sort' || type === 'filter') {
+                    return data;
                 }
-                return d;
+                
+                // Handle currency formatting
+                if (field.format === 'currency') {
+                    return `$${Number(data).toLocaleString()}`;
+                }
+                
+                // Handle date formatting
+                if (field.format === 'date') {
+                    return new Date(data).toLocaleDateString();
+                }
+                
+                // Handle badge formatting if badges are configured
+                if (field.badges && field.badges[data]) {
+                    const colorClass = field.badges[data];
+                    
+                    // Check if it's a hex color or a Bootstrap class
+                    if (colorClass.startsWith('#')) {
+                        return `<span class="badge" style="background-color: ${colorClass}">${data}</span>`;
+                    } else {
+                        return `<span class="badge ${colorClass}">${data}</span>`;
+                    }
+                }
+                
+                // Special case for status field for backward compatibility
+                if (field.key === 'status' && !field.badges) {
+                    const cls = data === 'Active' ? 'bg-success' : 'bg-warning';
+                    return `<span class="badge ${cls}">${data}</span>`;
+                }
+                
+                // Default case - return the data as is
+                return data;
             }
         }));
 
@@ -277,7 +305,7 @@
                     }
                     
                     if (stat.format === 'currency') {
-                        formattedValue = `${value.toLocaleString()}`;
+                        formattedValue = `$${value.toLocaleString()}`;
                     } else {
                         formattedValue = value.toLocaleString();
                     }
@@ -295,7 +323,7 @@
                     }
                     
                     if (stat.format === 'currency') {
-                        formattedValue = `${value.toLocaleString()}`;
+                        formattedValue = `$${value.toLocaleString()}`;
                     } else {
                         formattedValue = value.toLocaleString();
                     }

--- a/config.js
+++ b/config.js
@@ -12,7 +12,21 @@ window.DATASET_CONFIG = {
         { key: 'salary',       title: 'Salary',       format: 'currency', visible: true },
         { key: 'location',     title: 'Location',     filter: 'select', visible: true },
         { key: 'joined',       title: 'Join Date',    format: 'date', visible: true },
-        { key: 'status',       title: 'Status',       filter: 'select', visible: true },
+        { 
+            key: 'status',     
+            title: 'Status',   
+            filter: 'select', 
+            visible: true,
+            badges: {
+                'Active': 'bg-success',
+                'On Leave': 'bg-warning',
+                'Contract': 'bg-info',
+                'Probation': 'bg-secondary',
+                'Terminated': 'bg-danger'
+                // Can also use hex colors like:
+                // 'Custom Status': '#ff5733'
+            }
+        },
         { key: 'notes',        title: 'Notes',        visible: false }
     ],
     stats: [


### PR DESCRIPTION
Add configurable badge colors

- Add support for status badges with custom colors
- Implement direct mapping of values to colors in config
- Support both Bootstrap color classes and hex color codes